### PR TITLE
Deleted defaults for socket options.

### DIFF
--- a/pyxbackup
+++ b/pyxbackup
@@ -23,7 +23,7 @@ xb_opt_mysql_user = None
 xb_opt_mysql_pass = None
 xb_opt_mysql_host = 'localhost'
 xb_opt_mysql_port = 3306
-xb_opt_mysql_sock = '/tmp/mysql.sock'
+xb_opt_mysql_sock = None
 xb_opt_mysql_cnf = None
 xb_opt_retention_binlogs = False
 xb_opt_compress = False
@@ -3460,7 +3460,7 @@ class PyxOptions(object):
     mysql_pass = None
     mysql_host = 'localhost'
     mysql_port = 3306
-    mysql_sock = '/tmp/mysql.sock'
+    mysql_sock = None
     mysql_cnf = None
     retention_binlogs = False
     compress = False


### PR DESCRIPTION
Commit comment:

```xb_opt_mysql_sock and mysql_sock changed to "None", so they don't override command with wrong socket. Fix for https://github.com/dotmanila/pyxbackup/issues/36```


## Tests

### custom my.cnf with no socket option

```
[root@tmp-centos ~]# cat /root/.my.cnf 
[client]
user=root
password = '123!@#AOEaoe'
```

```
[root@tmp-centos ~]# /usr/bin/python /root/bin/pyxbackup full
[10/09/2017 20:26:41] INFO: Running FULL backup, started at 2017-10-09 20:26:41
[10/09/2017 20:26:41] INFO: Running xtrabackup with command: xtrabackup --defaults-file=/root/.my.cnf  --host=localhost  --no-timestamp --backup --parallel=4 --rsync --binlog-info=on --target-dir /backup/dbbackup/data04/backups/full/2017_10_09-20_26_41
[10/09/2017 20:26:45] INFO: Cleaning up /backup/dbbackup/data04/work excluding ['2017_10_09-20_26_41-pyxbackup.log']
[10/09/2017 20:26:45] INFO: Pruning full backup /backup/dbbackup/data04/backups/full/2017_10_09-20_07_00
```
worked ok.

### custom my.cnf with socket option

```
[root@tmp-centos ~]# cat /root/.my.cnf
[client]
user=root
password = '123!@#AOEaoe'
socket = /var/lib/mysql/mysql.sock
```

```
[root@tmp-centos ~]# /usr/bin/python /root/bin/pyxbackup full
[10/09/2017 20:26:14] INFO: Running FULL backup, started at 2017-10-09 20:26:14
[10/09/2017 20:26:14] INFO: Running xtrabackup with command: xtrabackup --defaults-file=/root/.my.cnf  --host=localhost  --no-timestamp --backup --parallel=4 --rsync --binlog-info=on --target-dir /backup/dbbackup/data04/backups/full/2017_10_09-20_26_14
[10/09/2017 20:26:18] INFO: Cleaning up /backup/dbbackup/data04/work excluding ['2017_10_09-20_26_14-pyxbackup.log']
[10/09/2017 20:26:18] INFO: Pruning full backup /backup/dbbackup/data04/backups/full/2017_10_09-20_03_00
```
worked ok

### custom my.cnf with socket option set to incorrect socket

```
[root@tmp-centos ~]# cat /root/.my.cnf
[client]
user=root
password = '123!@#AOEaoe'
socket = /var/lib/mysql/mysql2.sock
```

failed, as expected, and incorrect socket was used (meaning it was not overridden by the tool):
```
[root@tmp-centos ~]# /usr/bin/python /root/bin/pyxbackup full
[10/09/2017 20:24:41] INFO: Running FULL backup, started at 2017-10-09 20:24:41
[10/09/2017 20:24:41] INFO: Running xtrabackup with command: xtrabackup --defaults-file=/root/.my.cnf  --host=localhost  --no-timestamp --backup --parallel=4 --rsync --binlog-info=on --target-dir /backup/dbbackup/data04/backups/full/2017_10_09-20_24_41
[10/09/2017 20:24:43] ERROR: Command was: xtrabackup --defaults-file=/root/.my.cnf  --host=localhost  --no-timestamp --backup --parallel=4 --rsync --binlog-info=on --target-dir /backup/dbbackup/data04/backups/full/2017_10_09-20_24_41
[10/09/2017 20:24:43] ERROR: Error: process exited with status Non-zero exit of innobackupex command!
[10/09/2017 20:24:43] ERROR: Please check innobackupex log file at /backup/dbbackup/data04/work/2017_10_09-20_24_41-innobackupex-backup.log



[root@tmp-centos ~]# cat  /backup/dbbackup/data04/work/2017_10_09-20_24_41-innobackupex-backup.log
171009 20:24:41  version_check Connecting to MySQL server with DSN 'dbi:mysql:;mysql_read_default_group=xtrabackup;host=localhost;mysql_socket=/var/lib/mysql/mysql2.sock' as 'root'  (using password: YES).
Failed to connect to MySQL server: DBI connect(';mysql_read_default_group=xtrabackup;host=localhost;mysql_socket=/var/lib/mysql/mysql2.sock','root',...) failed: Can't connect to local MySQL server through socket '/var/lib/mysql/mysql2.sock' (2) at - line 1314.
171009 20:24:41 Connecting to MySQL server host: localhost, user: root, password: set, port: not set, socket: /var/lib/mysql/mysql2.sock
Failed to connect to MySQL server: Can't connect to local MySQL server through socket '/var/lib/mysql/mysql2.sock' (2).
```